### PR TITLE
Fix a bug

### DIFF
--- a/周杰伦.py
+++ b/周杰伦.py
@@ -22,7 +22,7 @@ class Concert:
     def __init__(self):
         self.status = 0  # 状态, 表示当前操作执行到了哪个步骤
         self.login_method = 1  # {0:模拟登录, 1:cookie登录}自行选择登录的方式
-        self.driver = webdriver.Chrome(executable_path='chromedriver.exe')  # 当前浏览器驱动对象
+        self.driver = webdriver.Chrome()  # 当前浏览器驱动对象
 
     # cookies: 登录网站时出现的 记录用户信息用的
     def set_cookies(self):


### PR DESCRIPTION
Note: Remove executable_url from the argument, because selenium above the 4.6.0 you don't need to add executable_url and you don't need to download webdriver.